### PR TITLE
Bump .NET version to .NET 10

### DIFF
--- a/.github/workflows/publish-nuget-packages.yml
+++ b/.github/workflows/publish-nuget-packages.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          8.0.x
+          10.0.x
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Create packages

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
-          8.0.x
+          10.0.x
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Run tests

--- a/Marketplace.Abstractions/Marketplace.Abstractions.csproj
+++ b/Marketplace.Abstractions/Marketplace.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Marketplace.Memory/Marketplace.Memory.csproj
+++ b/Marketplace.Memory/Marketplace.Memory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Marketplace.Shopify/Marketplace.Shopify.csproj
+++ b/Marketplace.Shopify/Marketplace.Shopify.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Marketplace.Tests/Marketplace.Tests.csproj
+++ b/Marketplace.Tests/Marketplace.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Upgrades this repository from .NET 6/8 to **.NET 10** (`net10.0`).

**Changes:**
- Updated `TargetFramework(s)` in all project files to `net10.0`.
- Bumped the `setup-dotnet` version pin in CI workflows to `10.0.x`.

Builds cleanly against the .NET 10 SDK.